### PR TITLE
Changed the selected line background highlight

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -53,7 +53,7 @@ atom-text-editor, :host {
 
   //Active line color
   .line.cursor-line {
-    background: darken(@gray, 7%) !important;
+    background: fade(white, 7%) !important;
     // padding-left: 10px;
     // margin-left: -10px;
 }


### PR DESCRIPTION
In case you want to see the misspelled words on current line, alpha channel in
the background color is handy.

`fade(white, 7%)` produces the same color on current background as `darken(@gray, 7%)`used previously. -> both appear as `#303030`

previous state:
![old](https://cloud.githubusercontent.com/assets/7453394/14930462/510dd9d6-0e64-11e6-9ed4-cd374c8939af.gif)

new state:
![new](https://cloud.githubusercontent.com/assets/7453394/14930465/554f6398-0e64-11e6-94ad-97381d867e74.gif)
